### PR TITLE
Fixes of the Status.Update() calls and use Patch for finalizer

### DIFF
--- a/internal/controller/nonadminbackup_controller.go
+++ b/internal/controller/nonadminbackup_controller.go
@@ -351,7 +351,7 @@ func (r *NonAdminBackupReconciler) createVeleroDeleteBackupRequest(ctx context.C
 	// Status will be applied based on the current state of the DeleteBackupRequest.
 	updated := updateNonAdminBackupDeleteBackupRequestStatus(&nab.Status, deleteBackupRequest)
 	if updated {
-		if err := r.Status().Update(ctx, nab); err != nil {
+		if err := r.updateStatusWithRetry(ctx, logger, nab); err != nil {
 			logger.Error(err, "Failed to update NonAdminBackup Status after DeleteBackupRequest reconciliation")
 			return false, err
 		}
@@ -458,9 +458,10 @@ func (r *NonAdminBackupReconciler) deleteDeleteBackupRequestObjects(ctx context.
 func (r *NonAdminBackupReconciler) removeNabFinalizerUponVeleroBackupDeletion(ctx context.Context, logger logr.Logger, nab *nacv1alpha1.NonAdminBackup) (bool, error) {
 	logger.V(1).Info("VeleroBackup deleted, removing NonAdminBackup finalizer")
 
+	patch := client.MergeFrom(nab.DeepCopy())
 	controllerutil.RemoveFinalizer(nab, constant.NabFinalizerName)
 
-	if err := r.Update(ctx, nab); err != nil {
+	if err := r.Patch(ctx, nab, patch); err != nil {
 		logger.Error(err, "Failed to remove finalizer from NonAdminBackup")
 		return false, err
 	}
@@ -528,7 +529,7 @@ func (r *NonAdminBackupReconciler) validateSpec(ctx context.Context, logger logr
 			},
 		)
 		if updatedPhase || updatedCondition {
-			if updateErr := r.Status().Update(ctx, nab); updateErr != nil {
+			if updateErr := r.updateStatusWithRetry(ctx, logger, nab); updateErr != nil {
 				logger.Error(updateErr, statusUpdateError)
 				return false, updateErr
 			}
@@ -607,8 +608,9 @@ func (r *NonAdminBackupReconciler) setFinalizerOnNonAdminBackup(ctx context.Cont
 	// to ensure we won't risk having orphant Velero Backup resource, due to an unexpected error
 	// while adding finalizer after creatign Velero Backup
 	if !controllerutil.ContainsFinalizer(nab, constant.NabFinalizerName) {
+		patch := client.MergeFrom(nab.DeepCopy())
 		controllerutil.AddFinalizer(nab, constant.NabFinalizerName)
-		if err := r.Update(ctx, nab); err != nil {
+		if err := r.Patch(ctx, nab, patch); err != nil {
 			logger.Error(err, "Failed to add finalizer")
 			return false, err
 		}
@@ -813,15 +815,26 @@ func (r *NonAdminBackupReconciler) createVeleroBackupAndSyncWithNonAdminBackup(c
 
 // updateStatusWithRetry updates the NonAdminBackup status with retry logic to handle resource version conflicts
 func (r *NonAdminBackupReconciler) updateStatusWithRetry(ctx context.Context, logger logr.Logger, nab *nacv1alpha1.NonAdminBackup) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Always fetch the latest version before updating status
 		current := &nacv1alpha1.NonAdminBackup{}
 		if err := r.Get(ctx, client.ObjectKeyFromObject(nab), current); err != nil {
 			return err
 		}
 
-		// Copy the status we want to update to the latest version
-		current.Status = nab.Status
+		// Preserve existing conditions and merge in new status updates
+		// This prevents losing conditions that were set by other reconcile steps
+		current.Status.Phase = nab.Status.Phase
+		current.Status.VeleroBackup = nab.Status.VeleroBackup
+		current.Status.QueueInfo = nab.Status.QueueInfo
+		current.Status.VeleroDeleteBackupRequest = nab.Status.VeleroDeleteBackupRequest
+		current.Status.DataMoverDataUploads = nab.Status.DataMoverDataUploads
+		current.Status.FileSystemPodVolumeBackups = nab.Status.FileSystemPodVolumeBackups
+
+		// Merge conditions instead of replacing them
+		for _, newCondition := range nab.Status.Conditions {
+			meta.SetStatusCondition(&current.Status.Conditions, newCondition)
+		}
 
 		// Attempt status update on fresh resource version
 		if err := r.Status().Update(ctx, current); err != nil {

--- a/internal/controller/nonadminbackup_controller_test.go
+++ b/internal/controller/nonadminbackup_controller_test.go
@@ -122,21 +122,27 @@ func checkTestNonAdminBackupStatus(nonAdminBackup *nacv1alpha1.NonAdminBackup, e
 		}
 	}
 
-	if len(nonAdminBackup.Status.Conditions) != len(expectedStatus.Conditions) {
-		return fmt.Errorf("NonAdminBackup Status has %v Condition(s), expected to have %v", len(nonAdminBackup.Status.Conditions), len(expectedStatus.Conditions))
-	}
-	for index := range nonAdminBackup.Status.Conditions {
-		if nonAdminBackup.Status.Conditions[index].Type != expectedStatus.Conditions[index].Type {
-			return fmt.Errorf("NonAdminBackup Status Conditions [%v] Type %v is not equal to expected %v", index, nonAdminBackup.Status.Conditions[index].Type, expectedStatus.Conditions[index].Type)
+	// Check that all expected conditions are present with correct values
+	// More robust than exact array matching - allows for additional conditions or different ordering
+	for _, expectedCondition := range expectedStatus.Conditions {
+		found := false
+		for _, actualCondition := range nonAdminBackup.Status.Conditions {
+			if actualCondition.Type == expectedCondition.Type {
+				found = true
+				if actualCondition.Status != expectedCondition.Status {
+					return fmt.Errorf("NonAdminBackup Status Condition Type %v has Status %v, expected %v", expectedCondition.Type, actualCondition.Status, expectedCondition.Status)
+				}
+				if actualCondition.Reason != expectedCondition.Reason {
+					return fmt.Errorf("NonAdminBackup Status Condition Type %v has Reason %v, expected %v", expectedCondition.Type, actualCondition.Reason, expectedCondition.Reason)
+				}
+				if !strings.Contains(actualCondition.Message, expectedCondition.Message) {
+					return fmt.Errorf("NonAdminBackup Status Condition Type %v has Message %v, expected to contain %v", expectedCondition.Type, actualCondition.Message, expectedCondition.Message)
+				}
+				break
+			}
 		}
-		if nonAdminBackup.Status.Conditions[index].Status != expectedStatus.Conditions[index].Status {
-			return fmt.Errorf("NonAdminBackup Status Conditions [%v] Status %v is not equal to expected %v", index, nonAdminBackup.Status.Conditions[index].Status, expectedStatus.Conditions[index].Status)
-		}
-		if nonAdminBackup.Status.Conditions[index].Reason != expectedStatus.Conditions[index].Reason {
-			return fmt.Errorf("NonAdminBackup Status Conditions [%v] Reason %v is not equal to expected %v", index, nonAdminBackup.Status.Conditions[index].Reason, expectedStatus.Conditions[index].Reason)
-		}
-		if !strings.Contains(nonAdminBackup.Status.Conditions[index].Message, expectedStatus.Conditions[index].Message) {
-			return fmt.Errorf("NonAdminBackup Status Conditions [%v] Message %v does not contain expected message %v", index, nonAdminBackup.Status.Conditions[index].Message, expectedStatus.Conditions[index].Message)
+		if !found {
+			return fmt.Errorf("NonAdminBackup Status missing expected Condition Type %v", expectedCondition.Type)
 		}
 	}
 


### PR DESCRIPTION
Fixes of the Status.Update() calls and use Patch for finalizer
    
Modifications which allows to remove race condition in the Status and Finalizer updates.